### PR TITLE
WL-4017 Conversation open in Lessons tool with 'Return to Lesson' at top

### DIFF
--- a/tool/src/java/org/sakaiproject/lessonbuildertool/tool/producers/ShowItemProducer.java
+++ b/tool/src/java/org/sakaiproject/lessonbuildertool/tool/producers/ShowItemProducer.java
@@ -307,7 +307,17 @@ public class ShowItemProducer implements ViewComponentProducer, NavigationCaseRe
 		simplePageBean.addNextLink(tofill, item);
 	    }
 
-	    UIComponent iframe = UILink.make(tofill, "iframe1", params.getSource());
+		//check if item is of type Forum_Summary
+		String source;
+		if(item.getType() == SimplePageItem.FORUM_SUMMARY){
+			//get messageId, topicId and forumId from the parameters for the source url
+			source = myUrl()+ "/portal/tool/" + simplePageBean.getCurrentTool(simplePageBean.FORUMS_TOOL_ID)
+				+"/discussionForum/message/dfViewThreadDirect.jsf?&messageId=" + params.getMessageId()
+				+ "&topicId=" + params.getTopicId() + "&forumId=" + params.getForumId();
+		}else{
+			source = params.getSource();
+		}
+		UIComponent iframe = UILink.make(tofill, "iframe1", source);
 	    if (item != null && item.getType() == SimplePageItem.BLTI) {
 		String height = item.getHeight();
 		if (height == null || height.equals(""))

--- a/tool/src/java/org/sakaiproject/lessonbuildertool/tool/producers/ShowPageProducer.java
+++ b/tool/src/java/org/sakaiproject/lessonbuildertool/tool/producers/ShowPageProducer.java
@@ -2678,8 +2678,9 @@ public class ShowPageProducer implements ViewComponentProducer, DefaultView, Nav
 						UIOutput.make(tableRow, "forum-summary-widget-height", height);
 						//setting forums-messages url to get all recent messages for the site
 						UIOutput.make(tableRow, "forum-summary-site-url", myUrl() + "/direct/forums/messages/" + simplePageBean.getCurrentSiteId());
-						//setting this variable to redirect user to the particular message in the forums tool
-						UIOutput.make(tableRow, "forum-summary-view-url", myUrl() + "/portal/directtool/" + simplePageBean.getCurrentTool(simplePageBean.FORUMS_TOOL_ID));
+						//setting the url such that request goes to ShowItemProducer to display forum conversations inside Lessons tool
+						UIOutput.make(tableRow, "forum-summary-view-url", myUrl() + "/portal/tool/" + placement.getId()
+								+"/" + ShowItemProducer.VIEW_ID + "?itemId=" +i.getId()+"&sendingPage="+currentPage.getPageId());
 						//get numberOfConversations for the widget
 						String numberOfConversations = i.getAttribute("numberOfConversations") != null ? i.getAttribute("numberOfConversations") : "" ;
 						UIOutput.make(tableRow, "numberOfConversations", numberOfConversations);

--- a/tool/src/java/org/sakaiproject/lessonbuildertool/tool/view/GeneralViewParameters.java
+++ b/tool/src/java/org/sakaiproject/lessonbuildertool/tool/view/GeneralViewParameters.java
@@ -54,6 +54,10 @@ public class GeneralViewParameters extends SimpleViewParameters {
 	
 	public String author; // An author whose comments should be highlighted
 	public String placementId = null;
+	//variables added to display forum conversation inside Lessons tool
+	public String messageId = "";
+	public String topicId = "";
+	public String forumId = "";
 
 	public GeneralViewParameters() {
 		super();
@@ -186,6 +190,27 @@ public class GeneralViewParameters extends SimpleViewParameters {
 		return placementId;
 	}
 
+	public String getMessageId() {
+		return messageId;
+	}
 
+	public void setMessageId(String messageId) {
+		this.messageId = messageId;
+	}
 
+	public String getTopicId() {
+		return topicId;
+	}
+
+	public void setTopicId(String topicId) {
+		this.topicId = topicId;
+	}
+
+	public String getForumId() {
+		return forumId;
+	}
+
+	public void setForumId(String forumId) {
+		this.forumId = forumId;
+	}
 }

--- a/tool/src/webapp/css/Simplepagetool.css
+++ b/tool/src/webapp/css/Simplepagetool.css
@@ -1054,7 +1054,8 @@ padding: 10px 15px 0 15px
 }
 .forumSummaryLink{
  text-decoration: none;
- color: #444
+ color: #444;
+ margin-left: 5px;
 }
 .forumSummaryDate{
  font-size:12px;

--- a/tool/src/webapp/js/forum-summary.js
+++ b/tool/src/webapp/js/forum-summary.js
@@ -54,7 +54,7 @@ function showForums(forumsUrl, toolHref, itemsToShow, forumSummaryDiv  ){
 }
 function outputForums(messagesArray, toolHref, forumSummaryDiv){
 	var title = msg("simplepage.forum-header-title");
-	var text_for_forums = '<div class="forumSummaryHeaderDiv"><h3 class="forumSummaryHeader"><a href="'+toolHref+'" class="forumSummaryLink" target="_top" title ="'+title+'">'+title+'</a></h3></div>';
+	var text_for_forums = '<div class="forumSummaryHeaderDiv"><h3 class="forumSummaryHeader"><img alt="" class="item-image" src="/library/image/silk/comments.png"><a href="'+toolHref+'" class="forumSummaryLink" title ="'+title+'">'+title+'</a></h3></div>';
 	if(messagesArray.length == 0){
 		text_for_forums += '<p>'+msg("simplepage.forum-summary-no-message")+'</p>';
 	}
@@ -69,8 +69,8 @@ function outputForums(messagesArray, toolHref, forumSummaryDiv){
 			var min = date.getMinutes() < 10 ? '0' + date.getMinutes() : date.getMinutes();
 			//using javascript's toLocaleDateString() to include user's locale and local time zone
 			var date_time = hour + ":" + min + " " + date.toLocaleDateString();
-			var href = toolHref + "/discussionForum/message/dfViewThreadDirect.jsf?messageId=" + messagesArray[i].messageId + "&topicId=" +messagesArray[i].topicId + "&forumId=" + messagesArray[i].forumId;
-			text_for_forums+='<li class="forumSummaryItem"><a href="'+href+'" target="_top">'+messagesArray[i].entityTitle+'</a> by '+messagesArray[i].author+'</br><span class="forumSummaryDate">'+date_time+'</span></li>';
+			var href = toolHref + "&messageId=" + messagesArray[i].messageId + "&topicId=" +messagesArray[i].topicId + "&forumId=" + messagesArray[i].forumId;
+			text_for_forums+='<li class="forumSummaryItem"><a href="'+href+'">'+messagesArray[i].entityTitle+'</a> by '+messagesArray[i].author+'</br><span class="forumSummaryDate">'+date_time+'</span></li>';
 		}
 		text_for_forums+='</ul>';
 	}


### PR DESCRIPTION
Have changed each conversation url in widget to go to 'ShowItemProducer'
class where source url is set to forum tool. This displays each thread
inside Lessons with 'Return to Lessons' option at the top.
MessageId,topicId and forumId variables added in 'GeneralViewParameters'
class.
Comment icon added  just before the heading in the component header.
