### PR TITLE
WL-4274 Corrected 'More-info' url for calendar event in Lessons.

### DIFF
--- a/tool/src/java/org/sakaiproject/lessonbuildertool/tool/producers/ShowPageProducer.java
+++ b/tool/src/java/org/sakaiproject/lessonbuildertool/tool/producers/ShowPageProducer.java
@@ -2741,7 +2741,7 @@ public class ShowPageProducer implements ViewComponentProducer, DefaultView, Nav
 						//set url to get events for the calendar
 						UIOutput.make(tableRow, "site-events-url", myUrl() + "/direct/calendar/site/" + simplePageBean.getCurrentSiteId());
 						//set calendar tool url for more info of calendar event
-						UIOutput.make(tableRow, "event-tool-url", myUrl() + "/portal/directtool/" + simplePageBean.getCurrentTool(simplePageBean.CALENDAR_TOOL_ID) + "?eventReference=/calendar/event/" +simplePageBean.getCurrentSiteId() + "/main/");
+						UIOutput.make(tableRow, "event-tool-url", myUrl() + "/portal/directtool/" + simplePageBean.getCurrentTool(simplePageBean.CALENDAR_TOOL_ID) + "?eventReference=");
 					}else {
 						UIComponent unavailableText = UIOutput.make(tableRow, "content", messageLocator.getMessage("simplepage.textItemUnavailable"));
 						unavailableText.decorate(new UIFreeAttributeDecorator("class", "disabled-text-item"));

--- a/tool/src/webapp/js/lessons-calendar.js
+++ b/tool/src/webapp/js/lessons-calendar.js
@@ -38,6 +38,7 @@ $(function(){
                                     icon: this["eventImage"],
                                     event_id: this["eventId"],
                                     attachments: this["attachments"],
+                                    eventReference: this["eventReference"],
                                     end: endDate
                                 });
                             });
@@ -76,7 +77,7 @@ $(function(){
             else{
                 $("#eventAttachmentsDiv").hide();
             }
-            var more_info = moreInfoUrl + event.event_id + "&panel=Main&sakai_action=doDescription&sakai.state.reset=true";
+            var more_info = moreInfoUrl + event.eventReference + "&panel=Main&sakai_action=doDescription&sakai.state.reset=true";
             var fullDetailsText = msg("simplepage.calendar-more-info");
             //when Full Details is clicked, event in the Calendar tool is shown.
             $("#fullDetails").html("<a href=" + more_info + " target=_top>" + fullDetailsText + "</a>");


### PR DESCRIPTION
More-info url was not correct for the externally subscribed calendar
event. Calendar entity provider now returns event reference in the
json which is used to redirect to the event in the Calendar Tool.
